### PR TITLE
Fix reviews submenu

### DIFF
--- a/app/controllers/spree/admin/reviews_controller.rb
+++ b/app/controllers/spree/admin/reviews_controller.rb
@@ -7,7 +7,7 @@ class Spree::Admin::ReviewsController < Spree::Admin::ResourceController
 
   def approve
     review = Spree::Review.find(params[:id])
-    if review.update_attribute(:approved, true)
+    if review.update(:approved, true)
       flash[:notice] = Spree.t(:info_approve_review)
     else
       flash[:error] = Spree.t(:error_approve_review)

--- a/app/controllers/spree/admin/reviews_controller.rb
+++ b/app/controllers/spree/admin/reviews_controller.rb
@@ -8,7 +8,7 @@ class Spree::Admin::ReviewsController < Spree::Admin::ResourceController
   def approve
     review = Spree::Review.find(params[:id])
     if review.update(approved: true)
-      flash[:notice] = Spree.t(:info_approve_review)
+      flash[:success] = Spree.t(:info_approve_review)
     else
       flash[:error] = Spree.t(:error_approve_review)
     end

--- a/app/controllers/spree/admin/reviews_controller.rb
+++ b/app/controllers/spree/admin/reviews_controller.rb
@@ -7,7 +7,7 @@ class Spree::Admin::ReviewsController < Spree::Admin::ResourceController
 
   def approve
     review = Spree::Review.find(params[:id])
-    if review.update(:approved, true)
+    if review.update(approved: true)
       flash[:notice] = Spree.t(:info_approve_review)
     else
       flash[:error] = Spree.t(:error_approve_review)

--- a/app/overrides/add_reviews_tab_to_admin.rb
+++ b/app/overrides/add_reviews_tab_to_admin.rb
@@ -1,6 +1,0 @@
-Deface::Override.new(
-  virtual_path: 'spree/admin/shared/sub_menu/_product',
-  name: 'reviews_admin_tab',
-  insert_bottom: '[data-hook="admin_product_sub_tabs"]',
-  text: '<%= tab(:reviews, label: "review_management") %>'
-)

--- a/app/overrides/spree/admin/shared/_product_sub_menu/add_reviews_tab_to_admin.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_sub_menu/add_reviews_tab_to_admin.html.erb.deface
@@ -1,0 +1,4 @@
+<!-- insert_bottom "[data-hook='admin_product_sub_tabs']" -->
+<% if can? :admin, Spree::Review %>
+  <%= tab :reviews, url: spree.admin_reviews_path %>
+<% end %>

--- a/app/views/spree/admin/reviews/index.html.erb
+++ b/app/views/spree/admin/reviews/index.html.erb
@@ -66,7 +66,7 @@
 					<td><%= link_to_if review.ip_address, review.ip_address, "http://whois.domaintools.com/#{review.ip_address}", target: :blank %></td>
 					<td><%= l review.created_at, format: :short %></td>
 					<td data-hook="admin_reviews_index_row_actions" class="actions">
-						<%= link_to_with_icon 'save', Spree.t(:approve), approve_admin_review_url(review), no_text: true, class: 'save-mehtod' unless review.approved %>
+						<%= link_to_with_icon 'save', Spree.t(:approve), approve_admin_review_url(review), no_text: true, class: 'approve btn btn-default' unless review.approved %>
 						<%= link_to_edit review, no_text: true, class: 'edit' %>
 						<%= link_to_delete review, no_text: true %>
 					</td>

--- a/app/views/spree/admin/reviews/index.html.erb
+++ b/app/views/spree/admin/reviews/index.html.erb
@@ -66,7 +66,7 @@
 					<td><%= link_to_if review.ip_address, review.ip_address, "http://whois.domaintools.com/#{review.ip_address}", target: :blank %></td>
 					<td><%= l review.created_at, format: :short %></td>
 					<td data-hook="admin_reviews_index_row_actions" class="actions">
-						<%= link_to_with_icon 'save', Spree.t(:approve), approve_admin_review_url(review), no_text: true, class: 'approve btn btn-default' unless review.approved %>
+						<%= link_to_with_icon 'save', Spree.t(:approve), approve_admin_review_url(review), no_text: true, class: 'save-mehtod' unless review.approved %>
 						<%= link_to_edit review, no_text: true, class: 'edit' %>
 						<%= link_to_delete review, no_text: true %>
 					</td>

--- a/spec/controllers/admin/reviews_controller_spec.rb
+++ b/spec/controllers/admin/reviews_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Spree::Admin::ReviewsController, type: :controller do
 
   context '#approve' do
     it 'shows notice message when approved' do
-      review.update(:approved, true)
+      review.update(approved: true)
       get :approve, params: { id: review.id }
       expect(response).to redirect_to spree.admin_reviews_path
       expect(flash[:notice]).to eq Spree.t(:info_approve_review)

--- a/spec/controllers/admin/reviews_controller_spec.rb
+++ b/spec/controllers/admin/reviews_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Spree::Admin::ReviewsController, type: :controller do
 
   context '#approve' do
     it 'shows notice message when approved' do
-      review.update_attribute(:approved, true)
+      review.update(:approved, true)
       get :approve, params: { id: review.id }
       expect(response).to redirect_to spree.admin_reviews_path
       expect(flash[:notice]).to eq Spree.t(:info_approve_review)

--- a/spec/controllers/admin/reviews_controller_spec.rb
+++ b/spec/controllers/admin/reviews_controller_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe Spree::Admin::ReviewsController, type: :controller do
       review.update(approved: true)
       get :approve, params: { id: review.id }
       expect(response).to redirect_to spree.admin_reviews_path
-      expect(flash[:notice]).to eq Spree.t(:info_approve_review)
+      expect(flash[:success]).to eq Spree.t(:info_approve_review)
     end
 
     it 'shows error message when not approved' do
-      allow_any_instance_of(Spree::Review).to receive(:update_attribute).and_return(false)
+      allow_any_instance_of(Spree::Review).to receive(:update).and_return(false)
       get :approve, params: { id: review.id }
       expect(flash[:error]).to eq Spree.t(:error_approve_review)
     end


### PR DESCRIPTION
There was some file structure that probably changed when we moved to Solidus. Fixed the path and changed the reviews_tab file to DSL format.
https://app.asana.com/0/263330274018170/179365294189275